### PR TITLE
Adding LoggerConfig interface and updated New() func signature

### DIFF
--- a/log/channel_test.go
+++ b/log/channel_test.go
@@ -58,7 +58,11 @@ func TestNewLogCh(t *testing.T) {
 						w = append(w, mockChBufs[0][f])
 					}
 
-					l := New(mockEmptyPrefixes[0], JSONFormat, w...)
+					l := New(
+						WithPrefix(mockEmptyPrefixes[0]),
+						JSONCfg,
+						WithOut(w...),
+					)
 
 					obj := test{
 						log: log{
@@ -264,7 +268,11 @@ func TestNewLogChMultiLogger(t *testing.T) {
 								w = append(w, mockChBufs[f][g])
 							}
 
-							l := New(mockEmptyPrefixes[0], JSONFormat, w...)
+							l := New(
+								WithPrefix(mockEmptyPrefixes[0]),
+								JSONCfg,
+								WithOut(w...),
+							)
 							logs = append(logs, l)
 						}
 
@@ -490,7 +498,11 @@ func TestNewLogChMultiEntry(t *testing.T) {
 				w = append(w, mockChBufs[b][c])
 			}
 
-			l := New(prefix, TextFormat, w...)
+			l := New(
+				WithPrefix(prefix),
+				TextCfg,
+				WithOut(w...),
+			)
 			logs = append(logs, l)
 		}
 

--- a/log/conf.go
+++ b/log/conf.go
@@ -1,0 +1,23 @@
+package log
+
+import "os"
+
+type LoggerConfig interface {
+	Apply(*LoggerBuilder)
+}
+
+var LoggerConfigs = map[int]LoggerConfig{
+	0: LCDefault{},
+}
+
+var (
+	DefaultConfig LoggerConfig = LoggerConfigs[0]
+)
+
+type LCDefault struct{}
+
+func (c LCDefault) Apply(lb *LoggerBuilder) {
+	lb.fmt = TextFormat
+	lb.out = os.Stdout
+	lb.prefix = "log"
+}

--- a/log/conf.go
+++ b/log/conf.go
@@ -1,23 +1,122 @@
 package log
 
-import "os"
+import (
+	"io"
+	"os"
+)
 
 type LoggerConfig interface {
 	Apply(*LoggerBuilder)
 }
 
+type multiconf struct {
+	confs []LoggerConfig
+}
+
+func MultiConf(conf ...LoggerConfig) LoggerConfig {
+	allConf := make([]LoggerConfig, 0, len(conf))
+	allConf = append(allConf, conf...)
+
+	return &multiconf{allConf}
+}
+
+func (m multiconf) Apply(lb *LoggerBuilder) {
+	for _, c := range m.confs {
+		c.Apply(lb)
+	}
+}
+
+var defaultConfig LoggerConfig = &multiconf{
+	confs: []LoggerConfig{
+		LCTextFormat{},
+		LCStdOut{},
+		LCDefaultPrefix{},
+	},
+}
+
 var LoggerConfigs = map[int]LoggerConfig{
-	0: LCDefault{},
+	0: defaultConfig,
+	5: LCTextFormat{},
+	6: LCJSONFormat{},
+	7: LCStdOut{},
+	8: LCDefaultPrefix{},
 }
 
 var (
-	DefaultConfig LoggerConfig = LoggerConfigs[0]
+	DefaultCfg   LoggerConfig = LoggerConfigs[0]
+	TextCfg      LoggerConfig = LoggerConfigs[5]
+	JSONCfg      LoggerConfig = LoggerConfigs[6]
+	StdOutCfg    LoggerConfig = LoggerConfigs[7]
+	DefPrefixCfg LoggerConfig = LoggerConfigs[8]
 )
 
-type LCDefault struct{}
+type LCTextFormat struct{}
 
-func (c LCDefault) Apply(lb *LoggerBuilder) {
+func (c LCTextFormat) Apply(lb *LoggerBuilder) {
 	lb.fmt = TextFormat
+}
+
+type LCJSONFormat struct{}
+
+func (c LCJSONFormat) Apply(lb *LoggerBuilder) {
+	lb.fmt = JSONFormat
+}
+
+type LCStdOut struct{}
+
+func (c LCStdOut) Apply(lb *LoggerBuilder) {
 	lb.out = os.Stdout
+}
+
+type LCDefaultPrefix struct{}
+
+func (c LCDefaultPrefix) Apply(lb *LoggerBuilder) {
 	lb.prefix = "log"
+}
+
+type LCPrefix struct {
+	p string
+}
+
+func WithPrefix(prefix string) *LCPrefix {
+	return &LCPrefix{
+		p: prefix,
+	}
+}
+
+func (c *LCPrefix) Apply(lb *LoggerBuilder) {
+	lb.prefix = c.p
+}
+
+type LCOut struct {
+	out io.Writer
+}
+
+func WithOut(out ...io.Writer) *LCOut {
+	if len(out) == 0 {
+		return &LCOut{
+			out: os.Stdout,
+		}
+	}
+
+	if len(out) == 1 {
+		return &LCOut{
+			out: out[0],
+		}
+	}
+
+	if len(out) > 1 {
+		return &LCOut{
+			out: io.MultiWriter(out...),
+		}
+	}
+
+	// default
+	return &LCOut{
+		out: os.Stdout,
+	}
+}
+
+func (c *LCOut) Apply(lb *LoggerBuilder) {
+	lb.out = c.out
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -56,28 +56,21 @@ type LoggerBuilder struct {
 	fmt    LogFormatter
 }
 
-func NewLogger() *LoggerBuilder {
-	return &LoggerBuilder{}
-}
+func NewLogger(confs ...LoggerConfig) LoggerI {
+	builder := &LoggerBuilder{}
 
-func (lb *LoggerBuilder) Configure(confs ...LoggerConfig) *LoggerBuilder {
 	if len(confs) == 0 {
-		DefaultConfig.Apply(lb)
-		return lb
+		DefaultConfig.Apply(builder)
+	} else {
+		for _, conf := range confs {
+			conf.Apply(builder)
+		}
 	}
-
-	for _, conf := range confs {
-		conf.Apply(lb)
-	}
-	return lb
-}
-
-func (lb *LoggerBuilder) Build() LoggerI {
 
 	return &Logger{
-		out:    lb.out,
-		prefix: lb.prefix,
-		fmt:    lb.fmt,
+		out:    builder.out,
+		prefix: builder.prefix,
+		fmt:    builder.fmt,
 	}
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"io"
-	"os"
 	"sync"
 )
 
@@ -48,7 +47,7 @@ type LoggerI interface {
 	Tracef(format string, v ...interface{})
 }
 
-var std = New("log", TextFormat, os.Stdout)
+var std = New(defaultConfig)
 
 type LoggerBuilder struct {
 	out    io.Writer
@@ -56,16 +55,10 @@ type LoggerBuilder struct {
 	fmt    LogFormatter
 }
 
-func NewLogger(confs ...LoggerConfig) LoggerI {
+func New(confs ...LoggerConfig) LoggerI {
 	builder := &LoggerBuilder{}
 
-	if len(confs) == 0 {
-		DefaultCfg.Apply(builder)
-	} else {
-		for _, conf := range confs {
-			conf.Apply(builder)
-		}
-	}
+	MultiConf(confs...).Apply(builder)
 
 	if builder.out == nil {
 		StdOutCfg.Apply(builder)
@@ -93,23 +86,6 @@ type Logger struct {
 	prefix string
 	fmt    LogFormatter
 	meta   map[string]interface{}
-}
-
-func New(prefix string, format LogFormatter, outs ...io.Writer) LoggerI {
-	var out io.Writer
-
-	if len(outs) == 0 {
-		out = os.Stdout
-	} else if len(outs) > 0 {
-		out = io.MultiWriter(outs...)
-	}
-
-	return &Logger{
-		out:    out,
-		buf:    []byte{},
-		prefix: prefix,
-		fmt:    format,
-	}
 }
 
 // output setter methods

--- a/log/logger.go
+++ b/log/logger.go
@@ -50,6 +50,37 @@ type LoggerI interface {
 
 var std = New("log", TextFormat, os.Stdout)
 
+type LoggerBuilder struct {
+	out    io.Writer
+	prefix string
+	fmt    LogFormatter
+}
+
+func NewLogger() *LoggerBuilder {
+	return &LoggerBuilder{}
+}
+
+func (lb *LoggerBuilder) Configure(confs ...LoggerConfig) *LoggerBuilder {
+	if len(confs) == 0 {
+		DefaultConfig.Apply(lb)
+		return lb
+	}
+
+	for _, conf := range confs {
+		conf.Apply(lb)
+	}
+	return lb
+}
+
+func (lb *LoggerBuilder) Build() LoggerI {
+
+	return &Logger{
+		out:    lb.out,
+		prefix: lb.prefix,
+		fmt:    lb.fmt,
+	}
+}
+
 type Logger struct {
 	mu     sync.Mutex
 	out    io.Writer

--- a/log/logger.go
+++ b/log/logger.go
@@ -60,11 +60,23 @@ func NewLogger(confs ...LoggerConfig) LoggerI {
 	builder := &LoggerBuilder{}
 
 	if len(confs) == 0 {
-		DefaultConfig.Apply(builder)
+		DefaultCfg.Apply(builder)
 	} else {
 		for _, conf := range confs {
 			conf.Apply(builder)
 		}
+	}
+
+	if builder.out == nil {
+		StdOutCfg.Apply(builder)
+	}
+
+	if builder.fmt == nil {
+		TextCfg.Apply(builder)
+	}
+
+	if builder.prefix == "" {
+		DefPrefixCfg.Apply(builder)
 	}
 
 	return &Logger{

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -14,11 +14,15 @@ func TestTextFormatLogger(t *testing.T) {
 	regx := regexp.MustCompile(regxStr)
 
 	prefix := "test-new-logger"
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 	var buf bytes.Buffer
 
-	logger := New(prefix, format, &buf)
+	logger := New(
+		WithPrefix(prefix),
+		format,
+		WithOut(&buf),
+	)
 
 	logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
@@ -48,12 +52,16 @@ func TestTextFormatLogger(t *testing.T) {
 
 func TestJSONFormatLogger(t *testing.T) {
 	prefix := "test-new-logger"
-	format := JSONFormat
+	format := JSONCfg
 	msg := "test content"
 	buf := &bytes.Buffer{}
 	logEntry := &LogMessage{}
 
-	logger := New(prefix, format, buf)
+	logger := New(
+		WithPrefix(prefix),
+		format,
+		WithOut(buf),
+	)
 
 	logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
@@ -96,12 +104,15 @@ func TestNewSingleWriterLogger(t *testing.T) {
 	regx := regexp.MustCompile(regxStr)
 
 	prefix := "test-new-logger"
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 	var buf bytes.Buffer
 
-	logger := New(prefix, format, &buf)
-
+	logger := New(
+		WithPrefix(prefix),
+		format,
+		WithOut(&buf),
+	)
 	logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
 	logger.Log(logMessage)
@@ -134,7 +145,7 @@ func TestNewMultiWriterLogger(t *testing.T) {
 	regx := regexp.MustCompile(regxStr)
 
 	prefix := "test-new-logger"
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 
 	var buf1 bytes.Buffer
@@ -145,7 +156,11 @@ func TestNewMultiWriterLogger(t *testing.T) {
 		&buf1, &buf2, &buf3,
 	}
 
-	logger := New(prefix, format, &buf1, &buf2, &buf3)
+	logger := New(
+		WithPrefix(prefix),
+		format,
+		WithOut(&buf1, &buf2, &buf3),
+	)
 
 	logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
@@ -180,14 +195,17 @@ func TestNewDefaultWriterLogger(t *testing.T) {
 	regx := regexp.MustCompile(regxStr)
 
 	prefix := "test-new-logger"
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 
 	out := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	logger := New(prefix, format)
+	logger := New(
+		WithPrefix(prefix),
+		format,
+	)
 	logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
 	logger.Log(logMessage)
@@ -231,7 +249,7 @@ func TestNewDefaultWriterLogger(t *testing.T) {
 func TestLoggerSetOuts(t *testing.T) {
 	type test struct {
 		prefix string
-		format LogFormatter
+		format LoggerConfig
 		outs   []io.Writer
 		bufs   []*bytes.Buffer
 	}
@@ -242,7 +260,7 @@ func TestLoggerSetOuts(t *testing.T) {
 	regx := regexp.MustCompile(regxStr)
 
 	prefix := "test-new-logger"
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 
 	for i := 0; i < 5; i++ {
@@ -264,7 +282,10 @@ func TestLoggerSetOuts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		logger := New(test.prefix, test.format)
+		logger := New(
+			WithPrefix(test.prefix),
+			test.format,
+		)
 		logger.SetOuts(test.outs...)
 		logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
@@ -294,7 +315,7 @@ func TestLoggerSetOuts(t *testing.T) {
 func TestLoggerAddOuts(t *testing.T) {
 	type test struct {
 		prefix string
-		format LogFormatter
+		format LoggerConfig
 		outs   []io.Writer
 		bufs   []*bytes.Buffer
 	}
@@ -305,7 +326,7 @@ func TestLoggerAddOuts(t *testing.T) {
 	regx := regexp.MustCompile(regxStr)
 
 	prefix := "test-new-logger"
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 
 	for i := 1; i < 5; i++ {
@@ -327,7 +348,11 @@ func TestLoggerAddOuts(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		logger := New(test.prefix, test.format, test.outs[0])
+		logger := New(
+			WithPrefix(test.prefix),
+			test.format,
+			WithOut(test.outs[0]),
+		)
 		logger.AddOuts(test.outs[1:]...)
 		logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
@@ -356,7 +381,7 @@ func TestLoggerAddOuts(t *testing.T) {
 func TestLoggerPrefix(t *testing.T) {
 	type test struct {
 		prefix string
-		format LogFormatter
+		format LoggerConfig
 		outs   []io.Writer
 		bufs   []*bytes.Buffer
 	}
@@ -374,7 +399,7 @@ func TestLoggerPrefix(t *testing.T) {
 	regxStr := `^\[.*\]\s*\[info\]\s*\[(.*)\]\s*test content\s*$`
 	regx := regexp.MustCompile(regxStr)
 
-	format := TextFormat
+	format := TextCfg
 	msg := "test content"
 
 	for _, p := range testPrefixes {
@@ -388,7 +413,11 @@ func TestLoggerPrefix(t *testing.T) {
 	}
 
 	for id, test := range tests {
-		logger := New("old", test.format, test.outs...)
+		logger := New(
+			WithPrefix("old"),
+			test.format,
+			WithOut(test.outs...),
+		)
 		logger.Prefix(test.prefix)
 		logMessage := NewMessage().Level(LLInfo).Message(msg).Build()
 
@@ -437,14 +466,18 @@ func TestLoggerPrefix(t *testing.T) {
 func TestLoggerFields(t *testing.T) {
 
 	prefix := "test-new-logger"
-	format := JSONFormat
+	format := JSONCfg
 	msg := "test content"
 
 	for id, obj := range testObjects {
 		buf := &bytes.Buffer{}
 		logEntry := &LogMessage{}
 
-		logger := New(prefix, format, buf)
+		logger := New(
+			WithPrefix(prefix),
+			format,
+			WithOut(buf),
+		)
 
 		logger.Fields(obj).Info(msg)
 

--- a/log/message_test.go
+++ b/log/message_test.go
@@ -13,8 +13,12 @@ var mockLogger = struct {
 	logger LoggerI
 	buf    *bytes.Buffer
 }{
-	logger: New("test-message", JSONFormat, mockBuffer),
-	buf:    mockBuffer,
+	logger: New(
+		WithPrefix("test-message"),
+		JSONCfg,
+		WithOut(mockBuffer),
+	),
+	buf: mockBuffer,
 }
 
 var mockLogLevelsOK = []LogLevel{
@@ -2526,7 +2530,11 @@ func TestPrint(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -2626,7 +2634,11 @@ func TestPrintln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -2726,7 +2738,11 @@ func TestPrintf(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string
@@ -2833,7 +2849,11 @@ func TestLog(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -3018,7 +3038,11 @@ func TestPanic(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -3097,7 +3121,11 @@ func TestPanicln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -3176,7 +3204,11 @@ func TestPanicf(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string
@@ -3288,7 +3320,11 @@ func TestError(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -3388,7 +3424,11 @@ func TestErrorln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -3488,7 +3528,11 @@ func TestErrorf(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string
@@ -3595,7 +3639,11 @@ func TestWarn(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -3695,7 +3743,11 @@ func TestWarnln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -3795,7 +3847,11 @@ func TestWarnf(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string
@@ -3902,7 +3958,11 @@ func TestInfo(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -4002,7 +4062,11 @@ func TestInfoln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -4102,7 +4166,11 @@ func TestInfof(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string
@@ -4209,7 +4277,11 @@ func TestDebug(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -4309,7 +4381,11 @@ func TestDebugln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -4409,7 +4485,11 @@ func TestDebugf(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string
@@ -4516,7 +4596,11 @@ func TestTrace(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -4616,7 +4700,11 @@ func TestTraceln(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		msg     string
@@ -4716,7 +4804,11 @@ func TestTracef(t *testing.T) {
 	// std logger override
 	oldstd := std
 	buf := &bytes.Buffer{}
-	std = New("log", JSONFormat, buf)
+	std = New(
+		WithPrefix("log"),
+		JSONCfg,
+		WithOut(buf),
+	)
 
 	type test struct {
 		format  string

--- a/log/multilog_test.go
+++ b/log/multilog_test.go
@@ -30,12 +30,12 @@ var mockBufs = []*bytes.Buffer{
 }
 
 var mockLoggers = []LoggerI{
-	New(mockMultiPrefixes[0], JSONFormat, mockBufs[0]),
-	New(mockMultiPrefixes[1], JSONFormat, mockBufs[1]),
-	New(mockMultiPrefixes[2], JSONFormat, mockBufs[2]),
-	New(mockMultiPrefixes[3], JSONFormat, mockBufs[3]),
-	New(mockMultiPrefixes[4], JSONFormat, mockBufs[4]),
-	New(mockMultiPrefixes[5], JSONFormat, mockBufs[5]),
+	New(WithPrefix(mockMultiPrefixes[0]), JSONCfg, WithOut(mockBufs[0])),
+	New(WithPrefix(mockMultiPrefixes[1]), JSONCfg, WithOut(mockBufs[1])),
+	New(WithPrefix(mockMultiPrefixes[2]), JSONCfg, WithOut(mockBufs[2])),
+	New(WithPrefix(mockMultiPrefixes[3]), JSONCfg, WithOut(mockBufs[3])),
+	New(WithPrefix(mockMultiPrefixes[4]), JSONCfg, WithOut(mockBufs[4])),
+	New(WithPrefix(mockMultiPrefixes[5]), JSONCfg, WithOut(mockBufs[5])),
 }
 
 var mockMultiLogger = struct {
@@ -749,7 +749,11 @@ func TestMultiLoggerAddOuts(t *testing.T) {
 		}
 
 		multi := MultiLogger(
-			New("test-logger", JSONFormat, test.buf[0]),
+			New(
+				WithPrefix("test-logger"),
+				JSONCfg,
+				WithOut(test.buf[0]),
+			),
 		)
 
 		if len(test.buf) > 1 {
@@ -807,7 +811,7 @@ func TestMultiLoggerPrefix(t *testing.T) {
 				for d := 0; d < len(mockMultiPrefixes); d++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[d], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[d]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -1002,7 +1006,7 @@ func TestMultiLoggerFields(t *testing.T) {
 				for d := 0; d < len(mockMultiPrefixes); d++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[d], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[d]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -1178,7 +1182,7 @@ func TestMultiLoggerPrint(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -1365,7 +1369,7 @@ func TestMultiLoggerPrintln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -1548,7 +1552,7 @@ func TestMultiLoggerPrintf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -1580,7 +1584,7 @@ func TestMultiLoggerPrintf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -1777,7 +1781,7 @@ func TestMultiLoggerLog(t *testing.T) {
 					for e := 0; e < len(mockMultiPrefixes); e++ {
 						buf := &bytes.Buffer{}
 						bufs = append(bufs, buf)
-						logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+						logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 					}
 					mlogger := MultiLogger(logs...)
 
@@ -1810,7 +1814,7 @@ func TestMultiLoggerLog(t *testing.T) {
 					for e := 0; e < len(mockMultiPrefixes); e++ {
 						buf := &bytes.Buffer{}
 						bufs = append(bufs, buf)
-						logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+						logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 					}
 					mlogger := MultiLogger(logs...)
 
@@ -2033,7 +2037,7 @@ func TestMultiLoggerPanic(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -2241,7 +2245,7 @@ func TestMultiLoggerPanicln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -2445,7 +2449,7 @@ func TestMultiLoggerPanicf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -2476,7 +2480,7 @@ func TestMultiLoggerPanicf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -2721,7 +2725,7 @@ func TestMultiLoggerError(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -2908,7 +2912,7 @@ func TestMultiLoggerErrorln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3091,7 +3095,7 @@ func TestMultiLoggerErrorf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3123,7 +3127,7 @@ func TestMultiLoggerErrorf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3318,7 +3322,7 @@ func TestMultiLoggerWarn(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3505,7 +3509,7 @@ func TestMultiLoggerWarnln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3688,7 +3692,7 @@ func TestMultiLoggerWarnf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3720,7 +3724,7 @@ func TestMultiLoggerWarnf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -3915,7 +3919,7 @@ func TestMultiLoggerInfo(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4102,7 +4106,7 @@ func TestMultiLoggerInfoln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4285,7 +4289,7 @@ func TestMultiLoggerInfof(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4317,7 +4321,7 @@ func TestMultiLoggerInfof(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4512,7 +4516,7 @@ func TestMultiLoggerDebug(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4699,7 +4703,7 @@ func TestMultiLoggerDebugln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4882,7 +4886,7 @@ func TestMultiLoggerDebugf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -4914,7 +4918,7 @@ func TestMultiLoggerDebugf(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -5109,7 +5113,7 @@ func TestMultiLoggerTrace(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -5296,7 +5300,7 @@ func TestMultiLoggerTraceln(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -5479,7 +5483,7 @@ func TestMultiLoggerTracef(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 
@@ -5511,7 +5515,7 @@ func TestMultiLoggerTracef(t *testing.T) {
 				for e := 0; e < len(mockMultiPrefixes); e++ {
 					buf := &bytes.Buffer{}
 					bufs = append(bufs, buf)
-					logs = append(logs, New(mockMultiPrefixes[e], JSONFormat, buf))
+					logs = append(logs, New(WithPrefix(mockMultiPrefixes[e]), JSONCfg, WithOut(buf)))
 				}
 				mlogger := MultiLogger(logs...)
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -93,14 +94,24 @@ func main() {
 		).Build(),
 	)
 
-	go func() {
-		logCh <- log.NewMessage().Prefix("test-chan-log").Level(log.LLPanic).Message("break runime").Metadata(
-			map[string]interface{}{
-				"type":    "panic",
-				"data":    "this is a goroutine panic into a logger in a goroutine",
-				"test_id": 4,
-			},
-		).Build()
-	}()
+	// go func() {
+	// 	logCh <- log.NewMessage().Prefix("test-chan-log").Level(log.LLPanic).Message("break runime").Metadata(
+	// 		map[string]interface{}{
+	// 			"type":    "panic",
+	// 			"data":    "this is a goroutine panic into a logger in a goroutine",
+	// 			"test_id": 4,
+	// 		},
+	// 	).Build()
+	// }()
+
+	var newBuf = &bytes.Buffer{}
+
+	newLogger := log.NewLogger(
+		log.WithPrefix("multi-conf"),
+		log.WithOut(os.Stdout, newBuf),
+		log.TextCfg,
+	)
+
+	newLogger.Log(log.NewMessage().Message("hello universe!").Build())
 
 }

--- a/main.go
+++ b/main.go
@@ -30,8 +30,16 @@ func main() {
 
 	multi := log.MultiLogger(
 
-		log.New("alpha-log", &log.TextFmt{}),
-		log.New("beta-log", &log.JSONFmt{}, logFile1, logFile2, customLog),
+		log.New(
+			log.WithPrefix("alpha-log"),
+			log.TextCfg,
+		),
+		log.New(
+			log.WithPrefix("beta-log"),
+			log.JSONCfg,
+			log.WithOut(
+				logFile1, logFile2, customLog,
+			)),
 	)
 
 	multi.Info("test log")
@@ -106,7 +114,7 @@ func main() {
 
 	var newBuf = &bytes.Buffer{}
 
-	newLogger := log.NewLogger(
+	newLogger := log.New(
 		log.WithPrefix("multi-conf"),
 		log.WithOut(os.Stdout, newBuf),
 		log.TextCfg,


### PR DESCRIPTION
This feature updates the Logger's `New()` function by introducing a LoggerConfig interface. This is a simple interface to apply different configurations to your logger for added modularity.

__Previous Logger `New()` function signature__:

```go
New(prefix string, format LogFormatter, outs ...io.Writer) LoggerI
```

__New Logger `New()` function signature__:

```go
New(confs ...LoggerConfig) LoggerI
```

______________


This introduces the `LoggerConfig` interface, which only has an `Apply()` method:

```go
type LoggerConfig interface {
	Apply(*LoggerBuilder)
}
```

From this point forward, new configurations and more modularity can be added to each existing feature and logger, by creating a new piece of code that implements the `LoggerConfig` interface.

If no configuration parameters are added, the defaults are still initiated in this approach, however creating a new Logger is a bit different:

```go
logger := zlog.New(
  zlog.WithPrefix("awesome-service"),
  zlog.TextCfg,
  zlog.WithOut(os.Stdout, logbuf, logfile),
)
```