### PR TITLE
[Build] Add Bazel support

### DIFF
--- a/proto/gen_pbgo.sh
+++ b/proto/gen_pbgo.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+protoc --go_out=. proto/event.proto 
+protoc --go_out=plugins=grpc:proto proto/service.proto
+sed -i 's|event "./log/event"|event "github.com/zalgonoise/zlog/log/event"|'  proto/service/service.pb.go 


### PR DESCRIPTION
Generating the `.pb.go` files beforehand and using gazelle to write the dependencies for Bazel seems the best option, to allow the usage of the go compiler, and not being exclusively executed with Bazel.

Fixes #44 